### PR TITLE
Missing square brackets fix.

### DIFF
--- a/doc/classes/Gradient.xml
+++ b/doc/classes/Gradient.xml
@@ -75,7 +75,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="colors" type="PackedColorArray" setter="set_colors" getter="get_colors" default="PackedColorArray(0, 0, 0, 1, 1, 1, 1, 1)">
+		<member name="colors" type="PackedColorArray" setter="set_colors" getter="get_colors" default="PackedColorArray([Color.WHITE, Color.BLACK])">
 			Gradient's colors returned as a [PackedColorArray].
 		</member>
 		<member name="interpolation_mode" type="int" setter="set_interpolation_mode" getter="get_interpolation_mode" enum="Gradient.InterpolationMode" default="0">


### PR DESCRIPTION
```gdscript
var a = PackedColorArray(0, 0, 0, 1, 1, 1, 1, 1) # INVALID
var b = PackedColorArray([0, 0, 0, 1, 1, 1, 1, 1]) # VALID
var c = PackedColorArray([Color.WHITE, Color.BLACK]) # I preferred the legible one.
```
note: same typo exists in godot 3 `Gradient` reference.
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
